### PR TITLE
Update text syntax to use `(memory $i)`

### DIFF
--- a/test/core/load.wast
+++ b/test/core/load.wast
@@ -5,10 +5,10 @@
   (memory $mem2 1)
 
   (func (export "load1") (param i32) (result i64)
-    (i64.load $mem1 (local.get 0))
+    (i64.load (memory $mem1) (local.get 0))
   )
   (func (export "load2") (param i32) (result i64)
-    (i64.load $mem2 (local.get 0))
+    (i64.load (memory $mem2) (local.get 0))
   )
 
   (data (memory $mem1) (i32.const 0) "\01")
@@ -36,10 +36,10 @@
   (data (memory $mem2) (i32.const 50) "\0A\0B\0C\0D\0E")
 
   (func (export "read1") (param i32) (result i32)
-    (i32.load8_u $mem1 (local.get 0))
+    (i32.load8_u (memory $mem1) (local.get 0))
   )
   (func (export "read2") (param i32) (result i32)
-    (i32.load8_u $mem2 (local.get 0))
+    (i32.load8_u (memory $mem2) (local.get 0))
   )
 )
 

--- a/test/core/memory-multi.wast
+++ b/test/core/memory-multi.wast
@@ -7,13 +7,13 @@
   (memory $mem2 1)
 
   (func (export "init1") (result i32)
-    (memory.init $mem1 $d (i32.const 1) (i32.const 0) (i32.const 4))
-    (i32.load $mem1 (i32.const 1))
+    (memory.init $d (memory $mem1) (i32.const 1) (i32.const 0) (i32.const 4))
+    (i32.load (memory $mem1) (i32.const 1))
   )
 
   (func (export "init2") (result i32)
-    (memory.init $mem2 $d (i32.const 1) (i32.const 4) (i32.const 4))
-    (i32.load $mem2 (i32.const 1))
+    (memory.init $d (memory $mem2) (i32.const 1) (i32.const 4) (i32.const 4))
+    (i32.load (memory $mem2) (i32.const 1))
   )
 
   (data $d "\01\00\00\00" "\02\00\00\00")
@@ -28,13 +28,13 @@
   (memory $mem2 1)
 
   (func (export "fill1") (result i32)
-    (memory.fill $mem1 (i32.const 1) (i32.const 0x01) (i32.const 4))
-    (i32.load $mem1 (i32.const 1))
+    (memory.fill (memory $mem1) (i32.const 1) (i32.const 0x01) (i32.const 4))
+    (i32.load (memory $mem1) (i32.const 1))
   )
 
   (func (export "fill2") (result i32)
-    (memory.fill $mem2 (i32.const 1) (i32.const 0x02) (i32.const 2))
-    (i32.load $mem2 (i32.const 1))
+    (memory.fill (memory $mem2) (i32.const 1) (i32.const 0x02) (i32.const 2))
+    (i32.load (memory $mem2) (i32.const 1))
   )
 )
 

--- a/test/core/store.wast
+++ b/test/core/store.wast
@@ -5,17 +5,17 @@
   (memory $mem2 1)
 
   (func (export "load1") (param i32) (result i64)
-    (i64.load $mem1 (local.get 0))
+    (i64.load (memory $mem1) (local.get 0))
   )
   (func (export "load2") (param i32) (result i64)
-    (i64.load $mem2 (local.get 0))
+    (i64.load (memory $mem2) (local.get 0))
   )
 
   (func (export "store1") (param i32 i64)
-    (i64.store $mem1 (local.get 0) (local.get 1))
+    (i64.store (memory $mem1) (local.get 0) (local.get 1))
   )
   (func (export "store2") (param i32 i64)
-    (i64.store $mem2 (local.get 0) (local.get 1))
+    (i64.store (memory $mem2) (local.get 0) (local.get 1))
   )
 )
 
@@ -59,17 +59,17 @@
   (memory $mem2 (import "M2" "mem") 1)
 
   (func (export "load1") (param i32) (result i64)
-    (i64.load $mem1 (local.get 0))
+    (i64.load (memory $mem1) (local.get 0))
   )
   (func (export "load2") (param i32) (result i64)
-    (i64.load $mem2 (local.get 0))
+    (i64.load (memory $mem2) (local.get 0))
   )
 
   (func (export "store1") (param i32 i64)
-    (i64.store $mem1 (local.get 0) (local.get 1))
+    (i64.store (memory $mem1) (local.get 0) (local.get 1))
   )
   (func (export "store2") (param i32 i64)
-    (i64.store $mem2 (local.get 0) (local.get 1))
+    (i64.store (memory $mem2) (local.get 0) (local.get 1))
   )
 )
 
@@ -92,10 +92,10 @@
   (data (memory $mem2) (i32.const 50) "\0A\0B\0C\0D\0E")
 
   (func (export "read1") (param i32) (result i32)
-    (i32.load8_u $mem1 (local.get 0))
+    (i32.load8_u (memory $mem1) (local.get 0))
   )
   (func (export "read2") (param i32) (result i32)
-    (i32.load8_u $mem2 (local.get 0))
+    (i32.load8_u (memory $mem2) (local.get 0))
   )
 
   (func (export "copy-1-to-2")
@@ -103,7 +103,7 @@
     (local.set $i (i32.const 20))
     (loop $cont
       (br_if 1 (i32.eq (local.get $i) (i32.const 23)))
-      (i32.store8 $mem2 (local.get $i) (i32.load8_u $mem1 (local.get $i)))
+      (i32.store8 (memory $mem2) (local.get $i) (i32.load8_u (memory $mem1) (local.get $i)))
       (local.set $i (i32.add (local.get $i) (i32.const 1)))
       (br $cont)
     )
@@ -114,7 +114,7 @@
     (local.set $i (i32.const 50))
     (loop $cont
       (br_if 1 (i32.eq (local.get $i) (i32.const 54)))
-      (i32.store8 $mem1 (local.get $i) (i32.load8_u $mem2 (local.get $i)))
+      (i32.store8 (memory $mem1) (local.get $i) (i32.load8_u (memory $mem2) (local.get $i)))
       (local.set $i (i32.add (local.get $i) (i32.const 1)))
       (br $cont)
     )


### PR DESCRIPTION
This commit intends to apply #17 to the test suite by using `(memory
...)` instead of bare indices which can be confused with other proposals
such as SIMD which use bare indices for other purposes.