### PR TITLE
Switch order of load/store immediates in binary format

### DIFF
--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -210,11 +210,11 @@ let end_ s = expect 0x0b s "END opcode expected"
 let memop s =
   let pos = pos s in
   let flags = vu32 s in
-  let has_var = Int32.logand flags 0x40l <> 0l in
-  let align = Int32.(to_int (logand flags 0x3fl)) in
   require (I32.lt_u flags 0x80l) s pos "malformed memop flags";
-  let offset = vu32 s in
+  let has_var = Int32.logand flags 0x40l <> 0l in
   let x = if has_var then at var s else Source.(0l @@ no_region) in 
+  let align = Int32.(to_int (logand flags 0x3fl)) in
+  let offset = vu32 s in
   x, align, offset
 
 let block_type s =

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -148,8 +148,8 @@ struct
     let flags =
       Int32.(logor (of_int align) (if has_var then 0x40l else 0x00l)) in
     vu32 flags;
-    vu32 offset;
-    if has_var then var x
+    if has_var then var x;
+    vu32 offset
 
   let block_type = function
     | VarBlockType x -> vs33 x.it

--- a/proposals/multi-memory/Overview.md
+++ b/proposals/multi-memory/Overview.md
@@ -62,7 +62,7 @@ Execution:
 
 Binary format:
 
-* For loads and stores: Reinterpret the alignment value in the `memarg` as a bitfield; if bit 6 (the MSB of the first LEB byte) is set, then an `i32` memory index follows after the offset immediate (even with SIMD, alignment must not currently be larger than 4 in the logarithmic encoding, i.e., taking up the lower 3 bits, so this is more than safe).
+* For loads and stores: Reinterpret the alignment value in the `memarg` as a bitfield; if bit 6 (the MSB of the first LEB byte) is set, then an `i32` memory index follows after the alignment bitfield (even with SIMD, alignment must not currently be larger than 4 in the logarithmic encoding, i.e., taking up the lower 3 bits, so this is more than safe).
 
 * For other memory instructions: Replace the hard-coded `0x00` bytes with an `i32` memory index.
 


### PR DESCRIPTION
Fix #28.

@ashleynh, PTAL.