### PR TITLE
Clarify order of the memory.copy immediates

### DIFF
--- a/document/core/binary/instructions.rst
+++ b/document/core/binary/instructions.rst
@@ -226,10 +226,10 @@ Each variant of :ref:`memory instruction <syntax-instr-memory>` is encoded with 
      \hex{3E}~~m{:}\Bmemarg &\Rightarrow& \I64.\STORE\K{32}~m \\ &&|&
      \hex{3F}~~x{:}\Bmemidx &\Rightarrow& \MEMORYSIZE~x \\ &&|&
      \hex{40}~~x{:}\Bmemidx &\Rightarrow& \MEMORYGROW~x \\ &&|&
-     \hex{FC}~~8{:}\Bu32~~src{:}\Bdataidx~dst{:}\Bmemidx &\Rightarrow& \MEMORYINIT~dst~src \\ &&|&
-     \hex{FC}~~9{:}\Bu32~~dst{:}\Bdataidx &\Rightarrow& \DATADROP~dst \\ &&|&
-     \hex{FC}~~10{:}\Bu32~~dst{:}\Bmemidx~~src{:}\Bmemidx &\Rightarrow& \MEMORYCOPY~dst~src \\ &&|&
-     \hex{FC}~~11{:}\Bu32~~dst{:}\Bmemidx &\Rightarrow& \MEMORYFILL~dst \\
+     \hex{FC}~~8{:}\Bu32~~y{:}\Bdataidx~x{:}\Bmemidx &\Rightarrow& \MEMORYINIT~x~y \\ &&|&
+     \hex{FC}~~9{:}\Bu32~~x{:}\Bdataidx &\Rightarrow& \DATADROP~x \\ &&|&
+     \hex{FC}~~10{:}\Bu32~~x{:}\Bmemidx~~y{:}\Bmemidx &\Rightarrow& \MEMORYCOPY~x~y \\ &&|&
+     \hex{FC}~~11{:}\Bu32~~x{:}\Bmemidx &\Rightarrow& \MEMORYFILL~x \\
    \end{array}
 
 .. index:: numeric instruction

--- a/document/core/binary/instructions.rst
+++ b/document/core/binary/instructions.rst
@@ -226,10 +226,10 @@ Each variant of :ref:`memory instruction <syntax-instr-memory>` is encoded with 
      \hex{3E}~~m{:}\Bmemarg &\Rightarrow& \I64.\STORE\K{32}~m \\ &&|&
      \hex{3F}~~x{:}\Bmemidx &\Rightarrow& \MEMORYSIZE~x \\ &&|&
      \hex{40}~~x{:}\Bmemidx &\Rightarrow& \MEMORYGROW~x \\ &&|&
-     \hex{FC}~~8{:}\Bu32~~y{:}\Bdataidx~x{:}\Bmemidx &\Rightarrow& \MEMORYINIT~x~y \\ &&|&
-     \hex{FC}~~9{:}\Bu32~~x{:}\Bdataidx &\Rightarrow& \DATADROP~x \\ &&|&
-     \hex{FC}~~10{:}\Bu32~~x{:}\Bmemidx~~y{:}\Bmemidx &\Rightarrow& \MEMORYCOPY~x~y \\ &&|&
-     \hex{FC}~~11{:}\Bu32~~x{:}\Bmemidx &\Rightarrow& \MEMORYFILL~x \\
+     \hex{FC}~~8{:}\Bu32~~src{:}\Bdataidx~dst{:}\Bmemidx &\Rightarrow& \MEMORYINIT~dst~src \\ &&|&
+     \hex{FC}~~9{:}\Bu32~~dst{:}\Bdataidx &\Rightarrow& \DATADROP~dst \\ &&|&
+     \hex{FC}~~10{:}\Bu32~~dst{:}\Bmemidx~~src{:}\Bmemidx &\Rightarrow& \MEMORYCOPY~dst~src \\ &&|&
+     \hex{FC}~~11{:}\Bu32~~dst{:}\Bmemidx &\Rightarrow& \MEMORYFILL~dst \\
    \end{array}
 
 .. index:: numeric instruction

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -601,7 +601,7 @@ The |MEMORYSIZE| instruction returns the current size of a memory.
 The |MEMORYGROW| instruction grows a memory by a given delta and returns the previous size, or :math:`-1` if enough memory cannot be allocated.
 Both instructions operate in units of :ref:`page size <page-size>`.
 The |MEMORYFILL| instruction sets all values in a region of a memory to a given byte.
-The |MEMORYCOPY| instruction copies data from a source memory region (second *immediate* |memarg|) to a possibly overlapping destination region in another or the same memory (first *immediate* |memarg|).
+The |MEMORYCOPY| instruction copies data from a source memory region to a possibly overlapping destination region in another or the same memory; the first index denotes the destination.
 The |MEMORYINIT| instruction copies data from a :ref:`passive data segment <syntax-data>` into a memory.
 The |DATADROP| instruction prevents further use of a passive data segment. This instruction is intended to be used as an optimization hint. After a data segment is dropped its data can no longer be retrieved, so the memory used by this segment may be freed.
 

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -601,7 +601,7 @@ The |MEMORYSIZE| instruction returns the current size of a memory.
 The |MEMORYGROW| instruction grows a memory by a given delta and returns the previous size, or :math:`-1` if enough memory cannot be allocated.
 Both instructions operate in units of :ref:`page size <page-size>`.
 The |MEMORYFILL| instruction sets all values in a region of a memory to a given byte.
-The |MEMORYCOPY| instruction copies data from a source memory region to a possibly overlapping destination region in another or the same memory.
+The |MEMORYCOPY| instruction copies data from a source memory region (second *immediate* |memarg|) to a possibly overlapping destination region in another or the same memory (first *immediate* |memarg|).
 The |MEMORYINIT| instruction copies data from a :ref:`passive data segment <syntax-data>` into a memory.
 The |DATADROP| instruction prevents further use of a passive data segment. This instruction is intended to be used as an optimization hint. After a data segment is dropped its data can no longer be retrieved, so the memory used by this segment may be freed.
 


### PR DESCRIPTION
Clarify that the destination memory index comes first. There is a single test for that (memory_copy1), but I did not find anything about the order in the spec text.